### PR TITLE
Improve help output when run without arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This repository provides a simple script to upscale images. The script will try 
 ## Usage
 
 ```bash
-python3 upscale.py path/to/image.jpg
+python3 main.py path/to/image.jpg
 ```
 
-If no image path is provided, the script will prompt for one.
+If run without arguments, the script prints its available options along with an example.
 
 ### Options
 
@@ -27,7 +27,7 @@ If no image path is provided, the script will prompt for one.
 Set `UPSCALE_API_ENDPOINT` and `UPSCALE_API_KEY` environment variables to avoid passing them on every run.
 
 ```bash
-UPSCALE_API_KEY=your-key python3 upscale.py image.png
+UPSCALE_API_KEY=your-key python3 main.py image.png
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary
- update README to mention usage message
- defer library imports and add example in argument parser
- print usage information when no image is supplied

## Testing
- `python3 -m py_compile main.py`
- `python3 main.py` (prints help)


------
https://chatgpt.com/codex/tasks/task_e_685f2eb393d0832caba370e5c3349615